### PR TITLE
AEM-70 - add global leader attribute

### DIFF
--- a/lib/global_registry_models/entity/person.rb
+++ b/lib/global_registry_models/entity/person.rb
@@ -5,6 +5,7 @@ module GlobalRegistryModels
       attribute :last_name, String
       attribute :gsw_access, Boolean
       attribute :key_guid, String
+      attribute :global_leader, Boolean
 
       def initialize(params)
         super

--- a/lib/global_registry_models/version.rb
+++ b/lib/global_registry_models/version.rb
@@ -1,3 +1,3 @@
 module GlobalRegistryModels
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/test/global_registry_models/entity/base/persistence_test.rb
+++ b/test/global_registry_models/entity/base/persistence_test.rb
@@ -124,9 +124,8 @@ class GlobalRegistryModelsEntityBasePersistenceTest < Minitest::Test
   end
 
   def test_create_with_authentication
-    entity = GlobalRegistryModels::Entity::Person.create(first_name: 'test', last_name:'name', gsw_access: false, key_guid: 'FF223AZCS44XCS', client_integration_id: '1')
-    assert_requested :post, 'https://test-api.global-registry.org/entities', body:'{"entity":{"person":{"first_name":"test","last_name":"name","gsw_access":false,"client_integration_id":"1","authentication":{"key_guid":"FF223AZCS44XCS"}}}}'
+    entity = GlobalRegistryModels::Entity::Person.create(first_name: 'test', last_name:'name', gsw_access: false, global_leader: false, key_guid: 'FF223AZCS44XCS', client_integration_id: '1')
+    assert_requested :post, 'https://test-api.global-registry.org/entities', body:'{"entity":{"person":{"first_name":"test","last_name":"name","gsw_access":false,"global_leader":false,"client_integration_id":"1","authentication":{"key_guid":"FF223AZCS44XCS"}}}}'
   end
 
 end
-

--- a/test/global_registry_models/entity/person_test.rb
+++ b/test/global_registry_models/entity/person_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class GlobalRegistryModelsEntityPersonTest < Minitest::Test
 
   def test_initialize
-    person = GlobalRegistryModels::Entity::Person.new({'first_name' => 'test', 'gsw_access'=> true, 'authentication' => {'key_guid' => 'FF44131FFCXZ-11212ASAAS'}})
+    person = GlobalRegistryModels::Entity::Person.new({'first_name' => 'test', 'gsw_access'=> true, 'global_leader'=> false, 'authentication' => {'key_guid' => 'FF44131FFCXZ-11212ASAAS'}})
     assert_instance_of GlobalRegistryModels::Entity::Person, person
     assert_equal 'FF44131FFCXZ-11212ASAAS', person.key_guid
   end

--- a/test/support/stubs/global_registry_stubs.rb
+++ b/test/support/stubs/global_registry_stubs.rb
@@ -38,7 +38,7 @@ module GlobalRegistryStubs
           "to": 2
         }
       }))
-  
+
   # API responds with a 504
   stub_request(:get, "https://test-api.global-registry.org/entities?entity_type=slow_test").
   with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'Bearer test', 'User-Agent'=>'Ruby'}).
@@ -106,7 +106,7 @@ module GlobalRegistryStubs
       with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'Bearer test', 'User-Agent'=>'Ruby'}).
       to_return(:status => 200, :body => %({"entities":[{"test":{"id":"0000-0000-0000-0001","phone":"+1234567890","name":"Mr. Test","client_integration_id":"1234","is_active":true}},{"test":{"id":"0000-0000-0000-0002","phone":"1800TEST","name":"Count Testalot","client_integration_id":"2222","is_active":true}}],"meta":{"page":2,"next_page":false,"from":3,"to":4}}), :headers => {})
 
-    
+
 
     # Delete a "test" entity
     stub_request(:delete, "https://test-api.global-registry.org/entities/0000-0000-0000-0001").
@@ -753,7 +753,7 @@ stub_request(:put, "https://test-api.global-registry.org/measurement_types/0000-
   to_return(:status => 200, :body => "", :headers => {})
 
   stub_request(:post, "https://test-api.global-registry.org/entities").
-  with(:body => "{\"entity\":{\"person\":{\"first_name\":\"test\",\"last_name\":\"name\",\"gsw_access\":false,\"client_integration_id\":\"1\",\"authentication\":{\"key_guid\":\"FF223AZCS44XCS\"}}}}",
+  with(:body => "{\"entity\":{\"person\":{\"first_name\":\"test\",\"last_name\":\"name\",\"gsw_access\":false,\"global_leader\":false,\"client_integration_id\":\"1\",\"authentication\":{\"key_guid\":\"FF223AZCS44XCS\"}}}}",
        :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Authorization'=>'Bearer test', 'Content-Length'=>'156', 'Content-Type'=>'application/json', 'Timeout'=>'-1', 'User-Agent'=>'Ruby'}).
    to_return(status: 200, headers: {}, body: %({
         "entity": {
@@ -762,6 +762,7 @@ stub_request(:put, "https://test-api.global-registry.org/measurement_types/0000-
             "first_name": "test",
             "last_name": "name",
              "gsw_access": "false",
+            "global_leader": "false",
             "client_integration_id": "400BF486-58B8-11E5-9BB3-6BAC9D6E46F5",
             "authentication": {
               "key_guid": "FF223AZCS44XCS"


### PR DESCRIPTION
This is a required piece from https://github.com/CruGlobal/ararat/pull/16 which was missed. This PR adds `global_leader` to the list of person entity attributes.